### PR TITLE
update the branch name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,5 +11,5 @@ github:
   support_url: https://forum.yaksa.org
   documentation_url: https://github.com/pmodels/yaksa/wiki
   owner_url: https://github.com/orgs/pmodels/people
-  license_url: githubusercontent.com/pmodels/yaksa/master/COPYRIGHT
+  license_url: githubusercontent.com/pmodels/yaksa/main/COPYRIGHT
   cla_url: https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement


### PR DESCRIPTION
Yaksa's main branch will be `main`. This PR fixes the link.